### PR TITLE
Remove assert

### DIFF
--- a/src/aiff.rs
+++ b/src/aiff.rs
@@ -90,7 +90,7 @@ pub(super) struct Chunk<'a> {
 /// AIFFチャンクの情報
 /// * 'size' - ファイルサイズ(byte) - 8
 pub(super) struct AiffHeader {
-    pub size: u32,
+    pub _size: u32,
 }
 
 /// SSNDチャンクのOffset, BlockSize
@@ -109,7 +109,7 @@ pub(super) fn parse_aiff_header(input: &[u8]) -> IResult<&[u8], AiffHeader> {
     let (input, _) = tag(b"FORM")(input)?;
     let (input, size) = be_u32(input)?;
     let (input, _id) = alt((tag(b"AIFF"), tag(b"AIFC")))(input)?;
-    Ok((input, AiffHeader { size }))
+    Ok((input, AiffHeader { _size: size }))
 }
 
 /// 先頭のチャンクを取得する

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -195,8 +195,8 @@ impl<'a> PcmReader<'a> {
         };
 
         //AIFFの場合
-        if let Ok((input, aiff)) = aiff::parse_aiff_header(input) {
-            assert_eq!((file_length - 8) as u32, aiff.size);
+        if let Ok((input, _aiff)) = aiff::parse_aiff_header(input) {
+            // assert_eq!((file_length - 8) as u32, aiff.size);
             if let Ok((_, _)) = reader.parse_aiff(input) {
                 return reader;
             }


### PR DESCRIPTION
Hello, there is an assert which checks the AIFF file size and compares it with header. AIFF files sometimes have a bunch of padding, which causes the assert to fail, even if the entire file is properly decodeable. Also using asserts is bad idea, because users can't handle/catch them.

Thank you.