### PR TITLE
Extract aiff support to a crate feature.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pacmog"
-version = "0.4.1"
+version = "0.5.0"
 authors = ["Akiyuki Okayasu <akiyuki.okayasu@gmail.com>"]
 description = "PCM decording library"
 categories = ["multimedia::audio", "no-std", "embedded", "multimedia::encoding"]
@@ -26,3 +26,7 @@ criterion = "0.4.0"
 [[bench]]
 name = "bench"
 harness = false
+
+[features]
+default = []
+aiff = [] # Aiff support

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 pacmog is a decoding library for the PCM file.  
 Designed for use in playing the PCM file embedded in microcontroller firmware.  
 Rust has an include_bytes! macro to embed the byte sequence in the program. Using it, PCM files can be embedded in firmware and used for playback.  
-pacmog works with no_std by default.  
+pacmog works with no_std by default. AIFF is supported via the 'aiff' feature which requires std. 
 
 | Format          | Status |
 | :---            | :---: |
@@ -64,4 +64,4 @@ cargo criterion
 ## no_std
 
 pacmog works with no_std by default.  
-No setup is needed.  
+No setup is needed. The 'aiff' feature will disable no_std. 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,6 +25,8 @@
 //! }
 //! ```
 
+#![cfg_attr(not(feature = "aiff"), no_std)]
+
 use anyhow::{bail, ensure};
 use core::f32;
 use heapless::Vec;
@@ -35,6 +37,7 @@ use nom::number::complete::{
 use nom::Finish;
 use nom::{multi::fold_many1, IResult};
 
+#[cfg(feature = "aiff")]
 mod aiff;
 pub mod imaadpcm;
 mod wav;
@@ -86,6 +89,7 @@ pub struct PcmReader<'a> {
 }
 
 impl<'a> PcmReader<'a> {
+    #[cfg(feature = "aiff")]
     fn parse_aiff(&mut self, input: &'a [u8]) -> IResult<&[u8], &[u8]> {
         let (input, v) = fold_many1(
             aiff::parse_chunk,
@@ -195,6 +199,7 @@ impl<'a> PcmReader<'a> {
         };
 
         //AIFFの場合
+        #[cfg(feature = "aiff")]
         if let Ok((input, _aiff)) = aiff::parse_aiff_header(input) {
             // assert_eq!((file_length - 8) as u32, aiff.size);
             if let Ok((_, _)) = reader.parse_aiff(input) {

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -3037,6 +3037,7 @@ fn wav_linearpcm_specs() {
     assert_eq!(spec.num_samples, 240000);
 }
 
+#[cfg_attr(not(feature = "aiff"), ignore)]
 #[test]
 fn aiff_linearpcm_specs() {
     let data = include_bytes!("./resources/Sine440Hz_1ch_48000Hz_16.aif");
@@ -3061,6 +3062,7 @@ fn wav_float32_specs() {
     assert_eq!(spec.num_samples, 240000);
 }
 
+#[cfg_attr(not(feature = "aiff"), ignore)]
 #[test]
 fn aiff_float32_specs() {
     let data = include_bytes!("./resources/Sine440Hz_1ch_48000Hz_32FP.aif");
@@ -3217,6 +3219,7 @@ fn wav_64bit_float() {
     }
 }
 
+#[cfg_attr(not(feature = "aiff"), ignore)]
 #[test]
 fn aiff_16bit() {
     let aiff = include_bytes!("./resources/Sine440Hz_1ch_48000Hz_16.aif");
@@ -3238,6 +3241,7 @@ fn aiff_16bit() {
     }
 }
 
+#[cfg_attr(not(feature = "aiff"), ignore)]
 #[test]
 fn aiff_24bit() {
     let aiff = include_bytes!("./resources/Sine440Hz_1ch_48000Hz_24.aif");
@@ -3255,6 +3259,7 @@ fn aiff_24bit() {
     }
 }
 
+#[cfg_attr(not(feature = "aiff"), ignore)]
 #[test]
 fn aiff_32bit() {
     let aiff = include_bytes!("./resources/Sine440Hz_1ch_48000Hz_32.aif");
@@ -3272,6 +3277,7 @@ fn aiff_32bit() {
     }
 }
 
+#[cfg_attr(not(feature = "aiff"), ignore)]
 #[test]
 fn aiff_32bit_float() {
     let aiff = include_bytes!("./resources/Sine440Hz_1ch_48000Hz_32FP.aif");
@@ -3289,6 +3295,7 @@ fn aiff_32bit_float() {
     }
 }
 
+#[cfg_attr(not(feature = "aiff"), ignore)]
 #[test]
 fn aiff_64bit_float() {
     let aiff = include_bytes!("./resources/Sine440Hz_1ch_48000Hz_64FP.aif");


### PR DESCRIPTION
I'm trying to use pacmog on a Raspberry Pi Pico and it failed to build with no_std. Looks like the issue is that aiff support is using f64::powf which is in std only. I looked into using micomath or libm, but they both only implement powf for f32. Instead, I've extracted the 'aiff' feature flag. It's disabled by default because the README explicitly states no_std working out of the box as a goal. As such, I've bumped the version to 0.5.0 since it's not backwards compatible.

Fixes AkiyukiOkayasu/pacmog#42.