### PR TITLE
Make pacmog no-alloc

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pacmog"
-version = "0.4.2"
+version = "0.5.0"
 authors = ["Akiyuki Okayasu <akiyuki.okayasu@gmail.com>"]
 description = "PCM decording library"
 categories = ["multimedia::audio", "no-std", "embedded", "multimedia::encoding"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,11 +12,11 @@ edition = "2021"
 rust-version = "1.79.0"
 
 [dependencies]
-anyhow = { version = "1.0.86", default-features = false }
 arbitrary-int = { version = "1.2.7", default-features = false }
 fixed = "1.23.1"
 heapless = "0.8.0"
 nom = { version = "7.1.3", default-features = false }
+embedded-error-chain = "1.0.0"
 
 [dev-dependencies]
 cpal = "0.15.2"

--- a/examples/beep_imaadpcm.rs
+++ b/examples/beep_imaadpcm.rs
@@ -34,7 +34,7 @@ fn main() {
                             }
                         }
                         Err(e) => {
-                            println!("{e}");
+                            println!("{e:?}");
                             let _result = complete_tx.try_send(());
                         }
                     }

--- a/examples/beep_imaadpcm_stereo.rs
+++ b/examples/beep_imaadpcm_stereo.rs
@@ -38,7 +38,7 @@ fn main() {
                             }
                         }
                         Err(e) => {
-                            println!("{e}");
+                            println!("{e:?}");
                             let _result = complete_tx.try_send(());
                         }
                     }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,0 +1,27 @@
+use embedded_error_chain::ErrorCategory;
+
+#[derive(Clone, Copy, ErrorCategory)]
+#[repr(u8)]
+pub enum DecodingError {
+    UnknownFormat,
+    UnsupportedBitDepth,
+    UnsupportedFormat
+}
+
+
+#[derive(Clone, Copy, ErrorCategory)]
+#[error_category(links(DecodingError))]
+#[repr(u8)]
+pub enum ReaderError {
+    InvalidChannel,
+    InvalidSample,
+    DecodingError
+}
+
+#[derive(Clone, Copy, ErrorCategory)]
+#[repr(u8)]
+pub enum PlayerError {
+    InvalidOutputBufferLength,
+    InvalidData,
+    FinishedPlaying
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -5,9 +5,8 @@ use embedded_error_chain::ErrorCategory;
 pub enum DecodingError {
     UnknownFormat,
     UnsupportedBitDepth,
-    UnsupportedFormat
+    UnsupportedFormat,
 }
-
 
 #[derive(Clone, Copy, ErrorCategory)]
 #[error_category(links(DecodingError))]
@@ -15,7 +14,7 @@ pub enum DecodingError {
 pub enum ReaderError {
     InvalidChannel,
     InvalidSample,
-    DecodingError
+    DecodingError,
 }
 
 #[derive(Clone, Copy, ErrorCategory)]
@@ -23,5 +22,5 @@ pub enum ReaderError {
 pub enum PlayerError {
     InvalidOutputBufferLength,
     InvalidData,
-    FinishedPlaying
+    FinishedPlaying,
 }

--- a/src/imaadpcm.rs
+++ b/src/imaadpcm.rs
@@ -170,7 +170,7 @@ impl<'a> ImaAdpcmPlayer<'a> {
         }
 
         // 再生終了
-        if ! (self.frame_index < self.reader.specs.num_samples) {
+        if !(self.frame_index < self.reader.specs.num_samples) {
             return Err(error::PlayerError::FinishedPlaying);
         }
 

--- a/src/wav.rs
+++ b/src/wav.rs
@@ -1,5 +1,4 @@
-use crate::{AudioFormat, PcmSpecs};
-use anyhow::ensure;
+use crate::{error, AudioFormat, PcmSpecs};
 use core::convert::TryInto;
 use nom::bytes::complete::{tag, take};
 use nom::number::complete::{le_u16, le_u32};
@@ -175,11 +174,11 @@ pub(super) fn parse_fmt(input: &[u8]) -> IResult<&[u8], WavFmtSpecs> {
 pub(super) fn calc_num_samples_per_channel(
     data_chunk_size_in_bytes: u32,
     spec: &PcmSpecs,
-) -> anyhow::Result<u32> {
-    ensure!(
-        spec.audio_format != AudioFormat::ImaAdpcmLe,
-        "IMA-ADPCM is not supported in calc_num_samples_per_channel"
-    );
+) -> Result<u32, error::DecodingError> {
+    if spec.audio_format == AudioFormat::ImaAdpcmLe {
+        return Err(error::DecodingError::UnsupportedFormat);
+    }
+
     Ok(data_chunk_size_in_bytes / (spec.bit_depth / 8u16 * spec.num_channels) as u32)
 }
 


### PR DESCRIPTION
As great as `anyhow` is, it requires a global allocator. Since pacmog is targeted towards embedded systems, requiring alloc limits its adoption. Doing that for an error framework seems like an awkward tradeoff. This PR replaces `anyhow` with [embeded_error_chain](https://crates.io/crates/embedded-error-chain) which is no-std and no-alloc.

Totally understand this is an unsolicited and somewhat large change. I need it for my use, so I'll maintain it on my own if I need to. Seemed like a reasonable speculative change though given pacmog's positioning.